### PR TITLE
Fixed typo in R/utils.R: inerits --> inherits

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -17,7 +17,7 @@ browse_ambiorix <- function(open, url){
     error = function(e) e
   )
 
-  if(inerits(x, "error"))
+  if(inherits(x, "error"))
     cat("Unable to open browser, please open manually.\n")
 
   invisible()


### PR DESCRIPTION
This is just a quick typo fix. The typo caused an error and prevented apps from launching.