### PR TITLE
use the user set host in the url

### DIFF
--- a/R/ambiorix.R
+++ b/R/ambiorix.R
@@ -174,7 +174,7 @@ Ambiorix <- R6::R6Class(
         )
       )
 
-      url <- sprintf("http://localhost:%s", port)
+      url <- sprintf("http://%s:%s", host, port)
       
       .globals$successLog$log("Listening on", url)
 


### PR DESCRIPTION
The host is currently hard coded for the console log.  This update makes it so that logged host is set to the host as specified by the "host" argument in `Ambiorid$new()` or the "ambiorix.host" option.