### PR TITLE
feat: ambiorix.htmltools_inline or copy_htmltools_dependencies

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -20,3 +20,4 @@ docker/
 ^test\.html$
 ^\.vscode$
 ^\.lintr$
+^[.]?air[.]toml$

--- a/R/response.R
+++ b/R/response.R
@@ -145,7 +145,8 @@ inline_dependencies <- function(deps) {
 }
 
 copy_htmltools_dependencies <- function(
-  deps, static_path = getOption("ambiorix.static_path", "www")
+  deps,
+  static_path = getOption("ambiorix.static_path", "www")
 ) {
   for (dep in deps) {
     src_dir <- dep$src$file
@@ -183,12 +184,12 @@ render_htmltools <- function(x) {
     rendered_deps <- htmltools::renderDependencies(deps)
     href_deps <- grep("http", strsplit(rendered_deps, "\n")[[1]], value = TRUE)
     href_deps <- paste0(href_deps, collapse = "\n")
-    deps_list <-  list(htmltools::HTML(href_deps), inline_deps)
+    deps_list <- list(htmltools::HTML(href_deps), inline_deps)
   } else {
     deps <- copy_htmltools_dependencies(deps)
     deps_list <- htmltools::renderDependencies(deps)
   }
-  
+
   # add <body> if not present, and enclose all children tags within it, <head> tags will
   # be extracted thanks to htmltools::renderTags
   if (!length(q$find("body")$selectedTags())) {

--- a/R/response.R
+++ b/R/response.R
@@ -144,6 +144,25 @@ inline_dependencies <- function(deps) {
   )
 }
 
+copy_htmltools_dependencies <- function(
+  deps, static_path = getOption("ambiorix.static_path", "www")
+) {
+  for (dep in deps) {
+    src_dir <- dep$src$file
+    dest_dir <- file.path(static_path, dep$name)
+    dir.create(dest_dir, recursive = TRUE, showWarnings = FALSE)
+    file.copy(
+      list.files(src_dir, full.names = TRUE),
+      dest_dir,
+      recursive = TRUE
+    )
+  }
+  for (i in seq_along(deps)) {
+    deps[[i]]$src$file <- file.path(static_path, deps[[i]]$name)
+  }
+  deps
+}
+
 render_htmltools <- function(x) {
   # if it has a <html> tag we assume
   # it's a document and render with
@@ -158,14 +177,18 @@ render_htmltools <- function(x) {
   deps <- htmltools::resolveDependencies(
     dependencies = htmltools::findDependencies(x)
   )
-  inline_deps <- inline_dependencies(deps)
 
-  # htmltools::renderDependencies(..., srcType = "href")
-  # does not work
-  rendered_deps <- htmltools::renderDependencies(deps)
-  href_deps <- grep("http", strsplit(rendered_deps, "\n")[[1]], value = TRUE)
-  href_deps <- paste0(href_deps, collapse = "\n")
-
+  if (isTRUE(getOption("ambiorix.htmltools_inline"))) {
+    inline_deps <- inline_dependencies(deps)
+    rendered_deps <- htmltools::renderDependencies(deps)
+    href_deps <- grep("http", strsplit(rendered_deps, "\n")[[1]], value = TRUE)
+    href_deps <- paste0(href_deps, collapse = "\n")
+    deps_list <-  list(htmltools::HTML(href_deps), inline_deps)
+  } else {
+    deps <- copy_htmltools_dependencies(deps)
+    deps_list <- htmltools::renderDependencies(deps)
+  }
+  
   # add <body> if not present, and enclose all children tags within it, <head> tags will
   # be extracted thanks to htmltools::renderTags
   if (!length(q$find("body")$selectedTags())) {
@@ -186,10 +209,8 @@ render_htmltools <- function(x) {
   )$prepend(
     htmltools::tags$meta(charset = "UTF-8")
   )$append(
-    htmltools::HTML(href_deps),
-    inline_deps
+    deps_list
   )
-
   # add placeholder for head tag children
   q$closest("html")$prepend(htmltools::HTML(
     "<head>\n<!--HEAD_CONTENT-->\n</head>"

--- a/tests/testthat/test-htmltools-deps.R
+++ b/tests/testthat/test-htmltools-deps.R
@@ -1,5 +1,4 @@
 test_that("copy_htmltools_dependencies works", {
-
   static_dir <- tempdir()
   options(
     "ambiorix.htmltools_inline" = FALSE,
@@ -15,7 +14,7 @@ test_that("copy_htmltools_dependencies works", {
     bootswatch = "quartz",
     primary = "#007bff",
     secondary = "#6c757d"
-  )  
+  )
 
   page <- page_navbar(
     theme = theme,
@@ -36,7 +35,6 @@ test_that("copy_htmltools_dependencies works", {
     )
   )
   resp <- Response$new()$send(tags$html(page))
-
 
   expect_true(
     grepl(paste0(static_dir, "/bs3compat/bs3compat.js"), resp$body),

--- a/tests/testthat/test-htmltools-deps.R
+++ b/tests/testthat/test-htmltools-deps.R
@@ -1,0 +1,45 @@
+test_that("copy_htmltools_dependencies works", {
+
+  static_dir <- tempdir()
+  options(
+    "ambiorix.htmltools_inline" = FALSE,
+    "ambiorix.static_path" = static_dir
+  )
+
+  library(bslib)
+  library(htmltools)
+  library(sass)
+
+  theme <- bs_theme(
+    version = 5,
+    bootswatch = "quartz",
+    primary = "#007bff",
+    secondary = "#6c757d"
+  )  
+
+  page <- page_navbar(
+    theme = theme,
+    title = "My App",
+    nav_panel(
+      "Home",
+      card(
+        card_header("Welcome"),
+        card_body("This is the home page content")
+      )
+    ),
+    nav_panel(
+      "About",
+      card(
+        card_header("About Us"),
+        card_body("This is the about page content")
+      )
+    )
+  )
+  resp <- Response$new()$send(tags$html(page))
+
+
+  expect_true(
+    grepl(paste0(static_dir, "/bs3compat/bs3compat.js"), resp$body),
+    info = "Dependencies included as files"
+  )
+})


### PR DESCRIPTION
This PR adds an option to copy htmltools dependencies to an static folder instead of inline them.

For example:
```
options(
    "ambiorix.htmltools_inline" = FALSE,
    "ambiorix.static_path" = "www"
  )
````