### PR TITLE
fix: change behaviour of send file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,19 +29,19 @@ Imports:
     methods,
     assertthat,
     webutils (>= 1.2.0),
-    yyjsonr (>= 0.1.20)
+    yyjsonr (>= 0.1.20),
+    mime (>= 0.13)
 Suggests:
-  mime,
-  readr,
-  readxl,
-  ggplot2,
-  promises,
-  jsonlite,
-  websocket,
-  htmltools,
-  commonmark,
-  htmlwidgets,
-  testthat (>= 3.0.0)
+    readr,
+    readxl,
+    ggplot2,
+    promises,
+    jsonlite,
+    websocket,
+    htmltools,
+    commonmark,
+    htmlwidgets,
+    testthat (>= 3.0.0)
 URL: https://github.com/ambiorix-web/ambiorix, https://ambiorix.dev
 BugReports: https://github.com/ambiorix-web/ambiorix/issues
 Config/testthat/edition: 3

--- a/R/response.R
+++ b/R/response.R
@@ -305,7 +305,21 @@ Response <- R6::R6Class(
       deprecated_headers(headers)
       deprecated_status(status)
       assert_that(not_missing(file))
-      self$render(file, data = list(), status = status, headers = headers)
+
+      body <- readBin(
+        con = file,
+        what = "raw",
+        n = file.info(file)$size
+      )
+
+      headers <- private$.get_headers()
+      headers[["Content-Type"]] <- mime::guess_type(file = file)
+
+      response(
+        status = private$.get_status(),
+        headers = headers,
+        body = body
+      )
     },
     #' @details Redirect to a path or URL.
     #' @param path Path or URL to redirect to.
@@ -853,7 +867,7 @@ Response <- R6::R6Class(
       # parse R
       private$.run_post_hooks(render_html(file_content), ext)
     },
-    .get_status = function(status) {
+    .get_status = function(status = NULL) {
       if (is.null(status)) {
         return(private$.status)
       }


### PR DESCRIPTION
closes #149 

this now works as expected:

```r
library(ambiorix)

app <- Ambiorix$new(port = 3000L)

app$get("/", function(req, res) {
  res$send("hello, world!")
})

app$get("/download", function(req, res) {
  res$send_file(file = "iris.csv")
})

app$start()
```

only caveat is i've added {mime} as an import, but {mime} itself has [no external dependencies](https://github.com/yihui/mime/blob/main/DESCRIPTION) so i guess it's okay?